### PR TITLE
Added TemporaryBind, MakeTemporaryBind

### DIFF
--- a/context/binding.h
+++ b/context/binding.h
@@ -264,6 +264,27 @@ inline bool IsActive(const Program& prog) {
 }
 #endif
 
+/// Binds a value. When the variable goes
+/// out of the scope, unbinds the value;
+template <typename T>
+class TemporaryBind {
+	//int valueBefore; //TODO
+	T const& val;
+public:
+	TemporaryBind(T const& val) :val(val) {
+		Bind(val);
+	}
+
+	~TemporaryBind() {
+		Unbind(val);
+	}
+};
+
+template <typename T>
+inline TemporaryBind<T> MakeTemporaryBind (T const& val) {
+	return TemporaryBind<T>(val);
+}
+
 }  // namespace oglwrap
 
 #include "../undefine_internal_macros.h"


### PR DESCRIPTION
They work similiar to TemporaryEnable/Disable. They Bind the value in the constructor, and unbind them in the destructor. 

MakeTemporaryBind makes it easier to use the functionality, you don't have to provide template arguments:
`auto bindVBO = gl::MakeTemporaryBind (VBO);`
using only TemporaryBind:
`gl::TemporaryBind<gl::ArrayBuffer> bindVBO(VBO);`

Also in the future the ability to restore the previous state can be added.