### PR TITLE
fix compiling problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ See [oglwrap_examples](https://github.com/Tomius/oglwrap_examples).
 Notes about using oglwrap:
 -------------
 - You have to load OpenGL extensions before including oglwrap with your preferred extension loader. If you don't have a preferred one, I recommend using [GLEW](https://github.com/nigels-com/glew).
+- When using [GLAD](https://glad.dav1d.de/), you should choose gl Version >= 4.1 and Compatibility Profile.

--- a/textures/texture_base-inl.h
+++ b/textures/texture_base-inl.h
@@ -164,12 +164,12 @@ void TextureBase<texture_t>::makeNonResident() {
 
 #if OGLWRAP_DEFINE_EVERYTHING || defined(glGetTexImage)
 template <TextureType texture_t>
-void TextureBase<texture_t>::getTextImage(GLint level,
+void TextureBase<texture_t>::getTexImage(GLint level,
                                           GLenum format,
                                           GLenum type,
                                           void* pixels) {
   OGLWRAP_CHECK_BINDING();
-  gl(GetTextImage(GLenum(texture_t), level, format, type, pixels));
+  gl(GetTexImage(GLenum(texture_t), level, format, type, pixels));
 }
 #endif
 

--- a/textures/texture_base.h
+++ b/textures/texture_base.h
@@ -169,7 +169,7 @@ class TextureBase {
     * @param type - Specifies a pixel type for the returned data. The supported types are GL_UNSIGNED_BYTE, GL_BYTE, GL_UNSIGNED_SHORT, GL_SHORT, GL_UNSIGNED_INT, GL_INT, GL_HALF_FLOAT, GL_FLOAT, GL_UNSIGNED_BYTE_3_3_2, GL_UNSIGNED_BYTE_2_3_3_REV, GL_UNSIGNED_SHORT_5_6_5, GL_UNSIGNED_SHORT_5_6_5_REV, GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_4_4_4_4_REV, GL_UNSIGNED_SHORT_5_5_5_1, GL_UNSIGNED_SHORT_1_5_5_5_REV, GL_UNSIGNED_INT_8_8_8_8, GL_UNSIGNED_INT_8_8_8_8_REV, GL_UNSIGNED_INT_10_10_10_2, GL_UNSIGNED_INT_2_10_10_10_REV, GL_UNSIGNED_INT_24_8, GL_UNSIGNED_INT_10F_11F_11F_REV, GL_UNSIGNED_INT_5_9_9_9_REV, and GL_FLOAT_32_UNSIGNED_INT_24_8_REV.
     * @param pixels - Returns the texture image. Should be a pointer to an array of the type specified by type.
     * @See glGetTexImage */
-  void getTextImage(GLint level,
+  void getTexImage(GLint level,
                     GLenum format,
                     GLenum type,
                     void* pixels);

--- a/vertex_attrib.h
+++ b/vertex_attrib.h
@@ -115,7 +115,9 @@ class VertexAttribObject {
     switch (type) {
       case DataType::kFloat:
       case DataType::kHalfFloat:
+#if OGLWRAP_DEFINE_EVERYTHING || defined(GL_FIXED)
       case DataType::kFixed:
+#endif
         pointer(values_per_vertex, type, false, stride, offset_pointer);
         break;
       case DataType::kDouble:


### PR DESCRIPTION
- typo: `glGetTextImage` does not exist, should be `glGetTexImage`
- seems that `GL_FIXED` is not defined in earlier versions, so add a macro check in its usage to stop compiler error
- according to [OpenGL Reference Pages](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGet.xhtml), glGetDoublei_v is not available until gl Version 4.1, so add a notice
- 2 error code macros are not defined in core mode, so add a notice